### PR TITLE
Search for CSV in calling script's directory

### DIFF
--- a/Remotely.psm1
+++ b/Remotely.psm1
@@ -81,7 +81,8 @@ param(
             $script:sessionsHashTable = @{}
         }
 
-        $machineConfigFile = Join-Path $PSScriptRoot "machineConfig.CSV"
+        $CallingScriptsDirectory = [System.IO.Path]::GetDirectoryName($MyInvocation.PSCommandPath)
+        $machineConfigFile = Join-Path $CallingScriptsDirectory "machineConfig.CSV"
 
         CreateSessions -machineConfigFile $machineConfigFile
 


### PR DESCRIPTION
When importing a module $PSScriptRoot is set to the module's directory not that of the calling script. Thus when you import remotely then look for $PSScriptRoot/machineConfig.CSV you aren't going to pull the config from the same directory as the calling script. This is IMHO a 'must have' feature for remotely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/remotely/20)
<!-- Reviewable:end -->
